### PR TITLE
Minor teaks to the README file

### DIFF
--- a/README
+++ b/README
@@ -41,7 +41,6 @@ https://www.maxmind.com/en/geolocation_landing
 
 As of version 1.4.5 geoipupdate can handle updates via  HTTP Proxy Server.
 If the environ variable http_proxy="http://proxy-host:port" is set.
-The username:password (as in FTP URLs) is not supported! 
 Thanks to Andrew Droffner for the patch!
 
 As of version 1.3.6, the GeoIP C library is thread safe, as long as
@@ -183,7 +182,7 @@ It seems that some
 versions of gcc have a bug and consume 1 GB of memory when optimizing
 certain source files (the other source file where this was reported is
 from XORG X-Server). It happens at least with gcc 3.3.1 and with gcc
-4.2(.0). Thanks to Kai Schätzl for the report.
+4.2(.0). Thanks to Kai Schï¿½tzl for the report.
 
 If GEOIP_MMAP_CACHE doesn't work on a 64bit machine, try adding
 the flag "MAP_32BIT" to the mmap call.
@@ -192,7 +191,7 @@ If you get a "passing argument 3 of 'gethostbyname_r' from incompatible pointer 
 error on AIX, download and/or untar a fresh copy of GeoIP. ( To avoid cached
 results from a previous ./configure run )
 
-cd ./GeoIP-1.4.6
+cd ./GeoIP-1.5.0
 then edit the file ./configure
 
 and delete these two lines:


### PR DESCRIPTION
- Removing the line about HTTP_PROXY not supporting credentials, since that was included in a recent pull request
- Also updated '1.4.6' reference to '1.5.0' in the troubleshooting section.
