### PR TITLE
Also fix timezone for CAQC to America/Toronto.

### DIFF
--- a/libGeoIP/timeZone.c
+++ b/libGeoIP/timeZone.c
@@ -321,7 +321,7 @@ const char* GeoIP_time_zone_by_country_and_region(const char * country,const cha
       timezone = "America/Halifax";
     }
     else if ( strcmp (region, "QC") == 0 ) {
-      timezone = "America/Montreal";
+      timezone = "America/Toronto";
     }
     else if ( strcmp (region, "SK") == 0 ) {
       timezone = "America/Regina";

--- a/timezone/timezone.txt
+++ b/timezone/timezone.txt
@@ -60,7 +60,7 @@ CA	NS	America/Halifax
 CA	NU	America/Rankin_Inlet
 CA	ON	America/Toronto
 CA	PE	America/Halifax
-CA	QC	America/Montreal
+CA	QC	America/Toronto
 CA	SK	America/Regina
 CA	YT	America/Whitehorse
 AU	01	Australia/Canberra


### PR DESCRIPTION
As per https://github.com/eggert/tz/commit/45dcf69b45087cff50282d4da64b86a7d705ddf3, America/Montreal was removed from zone tab. Update time_zone for Quebec, Canada.

See also https://bugs.launchpad.net/ubuntu/+source/ubiquity/+bug/1239127
