### PR TITLE
Fix the MinGW build

### DIFF
--- a/README.MinGW
+++ b/README.MinGW
@@ -1,8 +1,6 @@
 # how to build under MinGW/MSYS:
 # (first you need to build & "install" zlib)
 
-export "CFLAGS=-O3 -I/usr/local/include"
-export "LDFLAGS=-L/usr/local/lib -lwsock32 -lws2_32"
 ./configure
 make
 cp data/GeoIP.dat test/

--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,13 @@ AC_ARG_ENABLE([data-files],
 AS_IF([test "x$enable_data_files" != xno],
     AC_SUBST([GEOIP_DB_FILE],[GeoIP.dat]))
 
+case $host_os in
+    mingw* )
+        LDFLAGS="$LDFLAGS -lwsock32 -lws2_32"
+        ;;
+esac
+
+
 AC_OUTPUT([
 Makefile
 GeoIP.spec

--- a/libGeoIP/GeoIP.c
+++ b/libGeoIP/GeoIP.c
@@ -45,7 +45,7 @@ static geoipv6_t IPV6_NULL;
 #include <stdint.h>     /* For uint32_t */
 #endif
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include "pread.h"
 #endif
 

--- a/libGeoIP/GeoIP.h
+++ b/libGeoIP/GeoIP.h
@@ -159,8 +159,7 @@ typedef enum {
     GEOIP_CORPORATE_SPEED = 3,
 } GeoIPNetspeedValues;
 
-
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(__MINGW32__)
 #ifdef GEOIP_EXPORTS
 #define GEOIP_API __declspec(dllexport)
 #define GEOIP_DATA __declspec(dllexport)

--- a/libGeoIP/GeoIPCity.c
+++ b/libGeoIP/GeoIPCity.c
@@ -35,7 +35,7 @@
 #include <stdint.h>     /* For uint32_t */
 #endif
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include "pread.h"
 #endif
 

--- a/test/benchmark.c
+++ b/test/benchmark.c
@@ -56,7 +56,6 @@ double timerstop()
 
 void testgeoipcountry(int flags, const char *msg, int numlookups)
 {
-    const char *str = NULL;
     double t = 0;
     int i4 = 0;
     int i2 = 0;
@@ -68,7 +67,7 @@ void testgeoipcountry(int flags, const char *msg, int numlookups)
     }
     timerstart();
     for (i2 = 0; i2 < numlookups; i2++) {
-        str = GeoIP_country_name_by_addr(i, ipstring[i4]);
+        GeoIP_country_name_by_addr(i, ipstring[i4]);
         i4 = (i4 + 1) % numipstrings;
     }
     t = timerstop();
@@ -80,7 +79,6 @@ void testgeoipcountry(int flags, const char *msg, int numlookups)
 void testgeoiporg(int flags, const char *msg, int numlookups)
 {
     GeoIP *i = NULL;
-    char *i3 = NULL;
     int i4 = 0;
     int i2 = 0;
     double t = 0;

--- a/test/test-geoip-asnum.c
+++ b/test/test-geoip-asnum.c
@@ -30,14 +30,7 @@ int main(int argc, char *argv[])
     FILE *f;
     GeoIP *gi;
     char *org;
-    int generate = 0;
     char host[50];
-
-    if (argc == 2) {
-        if (!strcmp(argv[1], "gen")) {
-            generate = 1;
-        }
-    }
 
     gi = GeoIP_open("../data/GeoIPASNum.dat", GEOIP_STANDARD);
 

--- a/test/test-geoip-city.c
+++ b/test/test-geoip-city.c
@@ -31,15 +31,9 @@ int main(int argc, char *argv[])
     FILE *f;
     GeoIP *gi;
     GeoIPRecord *gir;
-    int generate = 0;
     char host[50];
     const char *time_zone = NULL;
     char **ret;
-    if (argc == 2) {
-        if (!strcmp(argv[1], "gen")) {
-            generate = 1;
-        }
-    }
 
     gi = GeoIP_open("../data/GeoIPCity.dat", GEOIP_INDEX_CACHE);
 

--- a/test/test-geoip-domain.c
+++ b/test/test-geoip-domain.c
@@ -32,14 +32,8 @@ main(int argc, char *argv[])
     FILE *f;
     GeoIP *gi;
     char *domain;
-    int generate = 0;
     char host[50];
     char **ret;
-    if (argc == 2) {
-        if (!strcmp(argv[1], "gen")) {
-            generate = 1;
-        }
-    }
 
     gi = GeoIP_open("../data/GeoIPDomain.dat", GEOIP_INDEX_CACHE);
 

--- a/test/test-geoip-isp.c
+++ b/test/test-geoip-isp.c
@@ -30,14 +30,7 @@ int main(int argc, char *argv[])
     FILE *f;
     GeoIP *gi;
     char *org;
-    int generate = 0;
     char host[50];
-
-    if (argc == 2) {
-        if (!strcmp(argv[1], "gen")) {
-            generate = 1;
-        }
-    }
 
     gi = GeoIP_open("../data/GeoIPISP.dat", GEOIP_STANDARD);
 

--- a/test/test-geoip-org.c
+++ b/test/test-geoip-org.c
@@ -30,14 +30,8 @@ int main(int argc, char *argv[])
     FILE *f;
     GeoIP *gi;
     char *org;
-    int generate = 0;
     char host[50];
     char **ret;
-    if (argc == 2) {
-        if (!strcmp(argv[1], "gen")) {
-            generate = 1;
-        }
-    }
 
     gi = GeoIP_open("../data/GeoIPOrg.dat", GEOIP_INDEX_CACHE);
 


### PR DESCRIPTION
This fixes both the static and shared MinGW build.

--

I stumbled over more possibly broken things while reading the source code.

For example, README.MinGW claims zlib is need to build GeoIP, but zlib.h isn't
included anywhere (well, besides in the outdated GeoIPWinDLL.patch file).

Another thing: It seems like the mutex in pread.c is never initialized
(DeleteCriticalSection() is missing too) when GeoIP is built as a static
library (probably just affects the MSVC build).
