### PR TITLE
Include io.h on Windows for lseek() and read()

### DIFF
--- a/libGeoIP/GeoIP.c
+++ b/libGeoIP/GeoIP.c
@@ -23,11 +23,13 @@
 
 static geoipv6_t IPV6_NULL;
 
-#if !defined(_WIN32)
+#if defined(_WIN32)
+#include <io.h>
+#else
 #include <unistd.h>
 #include <netdb.h>
 #include <sys/mman.h>
-#endif /* !defined(_WIN32) */
+#endif /* defined(_WIN32) */
 
 #include <errno.h>
 #include <stdio.h>


### PR DESCRIPTION
Fixes

    1>Z:\tmp\geoip\geoip-api-c\libGeoIP\GeoIP.c(933): warning C4013: 'lseek' undefiniert; Annahme: extern mit Rückgabetyp int
    1>Z:\tmp\geoip\geoip-api-c\libGeoIP\GeoIP.c(937): warning C4013: 'read' undefiniert; Annahme: extern mit Rückgabetyp int

Sorry, I don't have the english language pack installed, but it means something like:

"undefined; assuming extern returning int"
