### PR TITLE
Fix segfault in geoiplookup when passed invalid DB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ compiler:
 
 before_script:
   - ./bootstrap
-  - ./configure
+  - CFLAGS="-Wall -Wextra -Werror -Wno-unused-parameter" ./configure
   - make
 script:
   - make check

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 * A segmentation fault in `geoiplookup` was fixed when the utility was passed
-  an invalid database. This was reported in RedHat bug #1180874.
+  an invalid database. This was reported in Red Hat bug #1180874.
+* Additional validation was added for validation of the size used in the
+  creation of the index cache. Based on discussion in Red Hat bug #832913.
 
 
 1.6.4 2015-01-12

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+* A segmentation fault in `geoiplookup` was fixed when the utility was passed
+  an invalid database. This was reported in RedHat bug #1180874.
+
+
 1.6.4 2015-01-12
 
 * Update Fips codes (Boris Zentner)

--- a/apps/geoiplookup.c
+++ b/apps/geoiplookup.c
@@ -144,8 +144,7 @@ static const char * _mk_NA( const char * p )
     return p ? p : "N/A";
 }
 
-static unsigned long
-__addr_to_num(const char *addr)
+static unsigned long __addr_to_num(const char *addr)
 {
     unsigned int c, octet, t;
     unsigned long ipnum;
@@ -245,8 +244,7 @@ void _say_range_by_ip(GeoIP * gi, uint32_t ipnum )
     GeoIP_range_by_ip_delete(range);
 }
 
-void
-geoiplookup(GeoIP * gi, char *hostname, int i)
+void geoiplookup(GeoIP * gi, char *hostname, int i)
 {
     const char *country_code;
     const char *country_name;
@@ -263,9 +261,7 @@ geoiplookup(GeoIP * gi, char *hostname, int i)
     if (ipnum == 0) {
         printf("%s: can't resolve hostname ( %s )\n", GeoIPDBDescription[i],
                hostname);
-
     }else {
-
         if (GEOIP_DOMAIN_EDITION == i) {
             domain_name = GeoIP_name_by_ipnum(gi, ipnum);
             if (domain_name == NULL) {
@@ -370,18 +366,6 @@ geoiplookup(GeoIP * gi, char *hostname, int i)
                 printf("%s: Corporate\n", GeoIPDBDescription[i]);
             }
             _say_range_by_ip(gi, ipnum);
-        }else {
-
-            /*
-             * Silent ignore IPv6 databases. Otherwise we get annoying
-             * messages whenever we have a mixed environment IPv4 and
-             *  IPv6
-             */
-
-            /*
-             * printf("Can not handle database type -- try geoiplookup6\n");
-             */
-            ;
         }
     }
 }

--- a/apps/geoiplookup.c
+++ b/apps/geoiplookup.c
@@ -290,6 +290,10 @@ void geoiplookup(GeoIP * gi, char *hostname, int i)
             }
         }else if (GEOIP_COUNTRY_EDITION == i) {
             country_id = GeoIP_id_by_ipnum(gi, ipnum);
+            if (country_id < 0 || country_id >= (int) GeoIP_num_countries()) {
+                printf("%s: Invalid database\n", GeoIPDBDescription[i]);
+                return;
+            }
             country_code = GeoIP_country_code[country_id];
             country_name = GeoIP_country_name[country_id];
             if (country_id == 0) {

--- a/apps/geoiplookup6.c
+++ b/apps/geoiplookup6.c
@@ -177,7 +177,10 @@ geoiplookup(GeoIP * gi, char *hostname, int i)
             }
         }else if (GEOIP_COUNTRY_EDITION_V6 == i) {
             country_id = GeoIP_id_by_ipnum_v6(gi, ipnum);
-
+            if (country_id < 0 || country_id >= (int) GeoIP_num_countries()) {
+                printf("%s: Invalid database\n", GeoIPDBDescription[i]);
+                return;
+            }
             country_code = GeoIP_country_code[country_id];
             country_name = GeoIP_country_name[country_id];
             if (country_id == 0) {

--- a/apps/geoiplookup6.c
+++ b/apps/geoiplookup6.c
@@ -139,23 +139,7 @@ geoiplookup(GeoIP * gi, char *hostname, int i)
     if (__GEOIP_V6_IS_NULL(ipnum)) {
         printf("%s: can't resolve hostname ( %s )\n", GeoIPDBDescription[i],
                hostname);
-
     }else {
-
-
-#if 0
-        if (GEOIP_DOMAIN_EDITION_V6 == i) {
-            domain_name = GeoIP_name_by_name_v6(gi, hostname);
-            if (domain_name == NULL) {
-                printf("%s: IP Address not found\n", GeoIPDBDescription[i]);
-            }else {
-                printf("%s: %s\n", GeoIPDBDescription[i], domain_name);
-            }
-        }
-#endif
-
-
-
         if (GEOIP_LOCATIONA_EDITION_V6 == i || GEOIP_ASNUM_EDITION_V6 == i ||
             GEOIP_USERTYPE_EDITION_V6 == i || GEOIP_REGISTRAR_EDITION_V6 ==
             i ||
@@ -192,8 +176,8 @@ geoiplookup(GeoIP * gi, char *hostname, int i)
                        gir->area_code);
             }
         }else if (GEOIP_COUNTRY_EDITION_V6 == i) {
-
             country_id = GeoIP_id_by_ipnum_v6(gi, ipnum);
+
             country_code = GeoIP_country_code[country_id];
             country_name = GeoIP_country_name[country_id];
             if (country_id == 0) {
@@ -204,61 +188,4 @@ geoiplookup(GeoIP * gi, char *hostname, int i)
             }
         }
     }
-
-#if 0
-
-    else
-    if (GEOIP_REGION_EDITION_REV0 == i || GEOIP_REGION_EDITION_REV1 == i) {
-        region = GeoIP_region_by_name_v6(gi, hostname);
-        if (NULL == region) {
-            printf("%s: IP Address not found\n", GeoIPDBDescription[i]);
-        }else {
-            printf("%s: %s, %s\n", GeoIPDBDescription[i], region->country_code,
-                   region->region);
-            GeoIPRegion_delete(region);
-        }
-    }else if (GEOIP_CITY_EDITION_REV0 == i) {
-        gir = GeoIP_record_by_name(gi, hostname);
-        if (NULL == gir) {
-            printf("%s: IP Address not found\n", GeoIPDBDescription[i]);
-        }else {
-            printf("%s: %s, %s, %s, %s, %f, %f\n", GeoIPDBDescription[i],
-                   gir->country_code, gir->region,
-                   gir->city, gir->postal_code, gir->latitude,
-                   gir->longitude);
-        }
-    }else if (GEOIP_CITY_EDITION_REV1 == i) {
-        gir = GeoIP_record_by_name(gi, hostname);
-        if (NULL == gir) {
-            printf("%s: IP Address not found\n", GeoIPDBDescription[i]);
-        }else {
-            printf("%s: %s, %s, %s, %s, %f, %f, %d, %d\n",
-                   GeoIPDBDescription[i], gir->country_code, gir->region,
-                   gir->city,
-                   gir->postal_code,
-                   gir->latitude, gir->longitude, gir->metro_code,
-                   gir->area_code);
-        }
-    }else if (GEOIP_ORG_EDITION == i || GEOIP_ISP_EDITION == i) {
-        org = GeoIP_org_by_name_v6(gi, hostname);
-        if (org == NULL) {
-            printf("%s: IP Address not found\n", GeoIPDBDescription[i]);
-        }else {
-            printf("%s: %s\n", GeoIPDBDescription[i], org);
-        }
-    }else if (GEOIP_NETSPEED_EDITION == i) {
-        netspeed = GeoIP_id_by_name_v6(gi, hostname);
-        if (netspeed == GEOIP_UNKNOWN_SPEED) {
-            printf("%s: Unknown\n", GeoIPDBDescription[i]);
-        }else if (netspeed == GEOIP_DIALUP_SPEED) {
-            printf("%s: Dialup\n", GeoIPDBDescription[i]);
-        }else if (netspeed == GEOIP_CABLEDSL_SPEED) {
-            printf("%s: Cable/DSL\n", GeoIPDBDescription[i]);
-        }else if (netspeed == GEOIP_CORPORATE_SPEED) {
-            printf("%s: Corporate\n", GeoIPDBDescription[i]);
-        }
-
-    }
-#endif
-
 }

--- a/libGeoIP/GeoIP.c
+++ b/libGeoIP/GeoIP.c
@@ -918,8 +918,7 @@ static int _database_has_content( int database_type )
             && database_type != GEOIP_REGION_EDITION_REV1) ? 1 : 0;
 }
 
-static
-void _setup_segments(GeoIP * gi)
+static void _setup_segments(GeoIP * gi)
 {
     int i, j, segment_record_length;
     unsigned char delim[3];
@@ -1173,9 +1172,10 @@ int _check_mtime(GeoIP *gi)
                     if (gi->index_cache != NULL) {
                         if (pread(fileno(gi->GeoIPDatabase), gi->index_cache,
                                   idx_size, 0 ) != (ssize_t)idx_size) {
-                            DEBUG_MSGF(gi->flags,
-                                       "Error reading file %s where reloading\n",
-                                       gi->file_path);
+                            DEBUG_MSGF(
+                                gi->flags,
+                                "Error reading file %s where reloading\n",
+                                gi->file_path);
                             return -1;
                         }
                     }
@@ -1264,9 +1264,10 @@ unsigned int _GeoIP_seek_record_v6_gl(GeoIP *gi, geoipv6_t ipnum,
 
     /* shouldn't reach here */
     _GeoIP_inet_ntop(AF_INET6, &ipnum.s6_addr[0], paddr, ADDR_STR_LEN);
-    DEBUG_MSGF(gi->flags,
-               "Error Traversing Database for ipnum = %s - Perhaps database is corrupt?\n",
-               paddr);
+    DEBUG_MSGF(
+        gi->flags,
+        "Error Traversing Database for ipnum = %s - Perhaps database is corrupt?\n",
+        paddr);
     return 0;
 }
 
@@ -1352,9 +1353,10 @@ unsigned int _GeoIP_seek_record_gl(GeoIP *gi, unsigned long ipnum,
         offset = x;
     }
     /* shouldn't reach here */
-    DEBUG_MSGF(gi->flags,
-               "Error Traversing Database for ipnum = %lu - Perhaps database is corrupt?\n",
-               ipnum);
+    DEBUG_MSGF(
+        gi->flags,
+        "Error Traversing Database for ipnum = %lu - Perhaps database is corrupt?\n",
+        ipnum);
     return 0;
 }
 

--- a/libGeoIP/GeoIP.h
+++ b/libGeoIP/GeoIP.h
@@ -36,7 +36,7 @@ extern "C" {
 #define snprintf _snprintf
 #define FILETIME_TO_USEC(ft)                      \
     (((unsigned __int64)ft.dwHighDateTime << 32 | \
-        ft.dwLowDateTime) / 10)
+      ft.dwLowDateTime) / 10)
 #endif /* !defined(_WIN32) */
 
 #include <stdio.h>

--- a/libGeoIP/pread.c
+++ b/libGeoIP/pread.c
@@ -28,15 +28,15 @@ static CRITICAL_SECTION preadsc;
 
 #pragma section(".CRT$XCU",read)
 
-#define INITIALIZER(f)                                                         \
-    static void __cdecl f(void);                                               \
-    __declspec(allocate(".CRT$XCU")) void (__cdecl*f##_)(void) = f;            \
+#define INITIALIZER(f)                                                  \
+    static void __cdecl f(void);                                        \
+    __declspec(allocate(".CRT$XCU")) void(__cdecl * f ## _) (void) = f; \
     static void __cdecl f(void)
 
 #elif defined(__GNUC__)
 
-#define INITIALIZER(f)                                                         \
-    static void f(void) __attribute__((constructor));                          \
+#define INITIALIZER(f)                                \
+    static void f(void) __attribute__((constructor)); \
     static void f(void)
 
 #endif
@@ -97,8 +97,7 @@ static void deinitialize(void)
     DeleteCriticalSection(&preadsc);
 }
 
-INITIALIZER(initialize)
-{
+INITIALIZER(initialize){
     InitializeCriticalSection(&preadsc);
     atexit(deinitialize);
 }


### PR DESCRIPTION
This fixes the issue reported in:

https://bugzilla.redhat.com/show_bug.cgi?id=1180874

Although this fix acts as a good sanity check, a better fix would
be to not set the database type to GEOIP_COUNTRY_EDITION unless we
first verified that it was of this type. However, such a change may
break compatibility with some databases in the wild, and this is
a legacy product that is in maintenance-only mode.

See second commit for relevant changes.