### PR TITLE
Fix compiling issues on Windows - VS

### DIFF
--- a/libGeoIP/GeoIP.c
+++ b/libGeoIP/GeoIP.c
@@ -27,8 +27,14 @@ static geoipv6_t IPV6_NULL;
 #include <io.h>
 
 #ifdef _MSC_VER
-#  pragma warning (push)
-#  pragma warning (disable : 4996) // suppresses error for fileno on Windows VS builds
+#  if _MSC_VER < 1900 // VS 2015 supports snprintf
+#    define snprintf _snprintf
+#  endif
+#  if _MSC_VER >= 1400 // VS 2005+ deprecates fileno, lseek and read
+#    define fileno _fileno
+#    define read _read
+#    define lseek _lseek
+#  endif
 #endif
 #else
 #include <unistd.h>
@@ -2683,7 +2689,3 @@ int GeoIP_cleanup(void)
 
     return result;
 }
-
-#ifdef _MSC_VER
-#  pragma warning (pop) // restores
-#endif

--- a/libGeoIP/GeoIP.c
+++ b/libGeoIP/GeoIP.c
@@ -25,6 +25,11 @@ static geoipv6_t IPV6_NULL;
 
 #if defined(_WIN32)
 #include <io.h>
+
+#ifdef _MSC_VER
+#  pragma warning (push)
+#  pragma warning (disable : 4996) // suppresses error for fileno on Windows VS builds
+#endif
 #else
 #include <unistd.h>
 #include <netdb.h>
@@ -2679,3 +2684,6 @@ int GeoIP_cleanup(void)
     return result;
 }
 
+#ifdef _MSC_VER
+#  pragma warning (pop) // restores
+#endif

--- a/libGeoIP/GeoIP.h
+++ b/libGeoIP/GeoIP.h
@@ -33,7 +33,15 @@ extern "C" {
 #else /* !defined(_WIN32) */
 #include <winsock2.h>
 #include <ws2tcpip.h>
+
+#if defined(_MSC_VER)
+#pragma warning (disable:4996)
+
+#if _MSC_VER < 1900
 #define snprintf _snprintf
+#endif
+#endif
+
 #define FILETIME_TO_USEC(ft)                      \
     (((unsigned __int64)ft.dwHighDateTime << 32 | \
       ft.dwLowDateTime) / 10)

--- a/libGeoIP/GeoIP.h
+++ b/libGeoIP/GeoIP.h
@@ -34,12 +34,8 @@ extern "C" {
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
-#if defined(_MSC_VER)
-#pragma warning (disable:4996)
-
-#if _MSC_VER < 1900
-#define snprintf _snprintf
-#endif
+#if defined(_MSC_VER) && _MSC_VER < 1900
+#  define snprintf _snprintf
 #endif
 
 #define FILETIME_TO_USEC(ft)                      \

--- a/libGeoIP/GeoIP.h
+++ b/libGeoIP/GeoIP.h
@@ -33,11 +33,6 @@ extern "C" {
 #else /* !defined(_WIN32) */
 #include <winsock2.h>
 #include <ws2tcpip.h>
-
-#if defined(_MSC_VER) && _MSC_VER < 1900
-#  define snprintf _snprintf
-#endif
-
 #define FILETIME_TO_USEC(ft)                      \
     (((unsigned __int64)ft.dwHighDateTime << 32 | \
       ft.dwLowDateTime) / 10)

--- a/libGeoIP/GeoIPCity.c
+++ b/libGeoIP/GeoIPCity.c
@@ -29,6 +29,11 @@
 #else
 #include <windows.h>
 #include <winsock.h>
+
+#ifdef _MSC_VER
+#  pragma warning (push)
+#  pragma warning (disable : 4996) // suppresses error for fileno on Windows VS builds
+#endif
 #endif
 #include <sys/types.h>  /* For uint32_t */
 #ifdef HAVE_STDINT_H
@@ -354,3 +359,7 @@ GeoIPRecord_delete(GeoIPRecord * gir)
     free(gir->postal_code);
     free(gir);
 }
+
+#ifdef _MSC_VER
+#  pragma warning (pop) // restores
+#endif

--- a/libGeoIP/GeoIPCity.c
+++ b/libGeoIP/GeoIPCity.c
@@ -30,9 +30,10 @@
 #include <windows.h>
 #include <winsock.h>
 
-#ifdef _MSC_VER
-#  pragma warning (push)
-#  pragma warning (disable : 4996) // suppresses error for fileno on Windows VS builds
+#if defined(_MSC_VER) && _MSC_VER >= 1400 // VS 2005+ deprecates fileno, lseek and read
+#  define fileno _fileno
+#  define read _read
+#  define lseek _lseek
 #endif
 #endif
 #include <sys/types.h>  /* For uint32_t */
@@ -359,7 +360,3 @@ GeoIPRecord_delete(GeoIPRecord * gir)
     free(gir->postal_code);
     free(gir);
 }
-
-#ifdef _MSC_VER
-#  pragma warning (pop) // restores
-#endif


### PR DESCRIPTION
There were a few problems compiling a sample project including **libGeoIP** with Visual Studio on Windows.
This patch fixes them by doing a few version checks.

The first problem appeared in **Visual Studio 2015** and consisted in **snprintf** conflicts and the second problem was an error, actually telling you to add an underline **_** in the front of a few functions such **fileno**.