### PR TITLE
Fix compiling warning on Windows - VS

### DIFF
--- a/libGeoIP/GeoIPCity.c
+++ b/libGeoIP/GeoIPCity.c
@@ -140,14 +140,14 @@ _extract_record(GeoIP * gi, unsigned int seek_record, int *next_record_ptr)
     for (j = 0; j < 3; ++j) {
         latitude += (record_buf[j] << (j * 8));
     }
-    record->latitude = latitude / 10000 - 180;
+    record->latitude = (float)(latitude / 10000 - 180);
     record_buf += 3;
 
     /* get longitude */
     for (j = 0; j < 3; ++j) {
         longitude += (record_buf[j] << (j * 8));
     }
-    record->longitude = longitude / 10000 - 180;
+    record->longitude = (float)(longitude / 10000 - 180);
 
     /*
      * get area code and metro code for post April 2002 databases and for US


### PR DESCRIPTION
There were two warnings stating that transferring data from "double" to "float" can probably cause loss of data.
This patch fixes these two warning.