### PR TITLE
GeoIP_record_by_addr leads to a core dump on an empty database for 127.0.0.1

### DIFF
--- a/libGeoIP/GeoIPCity.c
+++ b/libGeoIP/GeoIPCity.c
@@ -96,6 +96,10 @@ _extract_record(GeoIP * gi, unsigned int seek_record, int *next_record_ptr)
             return NULL;
         }
     }else {
+        if (gi->size <= record_pointer) {
+            /* such record does not exists in the cache */
+            return NULL;
+        }
         record_buf = gi->cache + (long)record_pointer;
     }
 


### PR DESCRIPTION
How to reproduce:

Open database via 

GeoIP *db = GeoIP_open("./filename", GEOIP_MMAP_CACHE) ;

with GEOIP_MMAP_CACHE (or GEOIP_MEMORY_CACHE)  options, after that, get a record via ip addr:

GeoIP_record_by_addr (db, "127.0.0.1");

then GeoIP_record_by_addr generates a core dump.

GeoIP_record_by_ipnum and GeoIP_record_by_name generates a core dummp, too.
