### PR TITLE
Do nothing when pointer is NULL in GeoIPRecord_delete

### DIFF
--- a/libGeoIP/GeoIPCity.c
+++ b/libGeoIP/GeoIPCity.c
@@ -360,6 +360,9 @@ GeoIP_next_record(GeoIP * gi, GeoIPRecord ** gir, int *record_iter)
 void
 GeoIPRecord_delete(GeoIPRecord * gir)
 {
+    if (gir == NULL) {
+        return;
+    }
     free(gir->region);
     free(gir->city);
     free(gir->postal_code);


### PR DESCRIPTION
It's okay to pass `NULL` to the `free()` function, so does `GeoIP_delete()`, `GeoIPRegion_delete()`, etc. However, `GeoIPRecord_delete()` doesn't accept `NULL` as the parameter.

This patch fixes it by checking the input pointer before dereferencing it.