### PR TITLE
fix empty parameter list => void argument

### DIFF
--- a/apps/geoiplookup.c
+++ b/apps/geoiplookup.c
@@ -30,7 +30,7 @@ typedef unsigned int uint32_t;
 
 void geoiplookup(GeoIP * gi, char *hostname, int i);
 
-void usage()
+void usage(void)
 {
     fprintf(
         stderr,

--- a/apps/geoiplookup6.c
+++ b/apps/geoiplookup6.c
@@ -23,7 +23,7 @@
 #include "GeoIP_internal.h"
 void geoiplookup(GeoIP * gi, char *hostname, int i);
 
-void usage()
+void usage(void)
 {
     fprintf(
         stderr,

--- a/libGeoIP/GeoIP.c
+++ b/libGeoIP/GeoIP.c
@@ -770,7 +770,7 @@ char *_GeoIP_full_path_to(const char *file_name)
 
 char ** GeoIPDBFileName = NULL;
 
-void _GeoIP_setup_dbfilename()
+void _GeoIP_setup_dbfilename(void)
 {
     if (NULL == GeoIPDBFileName) {
         GeoIPDBFileName = malloc(sizeof(char *) * NUM_DB_TYPES);

--- a/libGeoIP/GeoIP_internal.h
+++ b/libGeoIP/GeoIP_internal.h
@@ -13,7 +13,7 @@ GEOIP_API unsigned long _GeoIP_lookupaddress(const char *host);
 GEOIP_API geoipv6_t _GeoIP_lookupaddress_v6(const char *host);
 GEOIP_API int __GEOIP_V6_IS_NULL(geoipv6_t v6);
 
-GEOIP_API void _GeoIP_setup_dbfilename();
+GEOIP_API void _GeoIP_setup_dbfilename(void);
 GEOIP_API char *_GeoIP_full_path_to(const char *file_name);
 
 /* deprecated */

--- a/test/benchmark.c
+++ b/test/benchmark.c
@@ -37,12 +37,12 @@ FILETIME timer_t2;
 #endif                          /* !defined(_WIN32) */
 
 #if !defined(_WIN32)
-void timerstart()
+void timerstart(void)
 {
     gettimeofday(&timer_t1, NULL);
 }
 
-double timerstop()
+double timerstop(void)
 {
     int a1 = 0;
     int a2 = 0;
@@ -58,12 +58,12 @@ double timerstop()
     return r;
 }
 #else                           /* !defined(_WIN32) */
-void timerstart()
+void timerstart(void)
 {
     GetSystemTimeAsFileTime(&timer_t1);
 }
 
-double timerstop()
+double timerstop(void)
 {
     __int64 delta;              /* VC6 can't convert an unsigned int64 to to double */
     GetSystemTimeAsFileTime(&timer_t2);
@@ -152,7 +152,7 @@ void testgeoipcity(int flags, const char *msg, int numlookups)
     GeoIP_delete(i);
 }
 
-int main()
+int main(void)
 {
     int time = 300 * numipstrings;
     testgeoipcountry(0, "GeoIP Country", 100 * time);

--- a/test/test-geoip-invalid-file.c
+++ b/test/test-geoip-invalid-file.c
@@ -1,6 +1,6 @@
 #include "GeoIP.h"
 
-int main()
+int main(void)
 {
     GeoIP *gi = GeoIP_open(SRCDIR "/README.md", GEOIP_MEMORY_CACHE);
 

--- a/test/test-geoip-region.c
+++ b/test/test-geoip-region.c
@@ -48,7 +48,7 @@ static const char *_mk_NA(const char *p)
     return p ? p : "N/A";
 }
 
-int main()
+int main(void)
 {
     GeoIP *gi;
     GeoIPRegion *gir, giRegion;

--- a/test/test-geoip.c
+++ b/test/test-geoip.c
@@ -20,7 +20,7 @@
 
 #include "GeoIP.h"
 
-int main()
+int main(void)
 {
     FILE *f;
     char *db_info;


### PR DESCRIPTION
With some compilation  (such as `-Wstrict-prototypes`) gcc produces warning on non-correct types.
In conjunction with `-Werror` this can lead to compilation failures.