### PR TITLE
libgeoip: add GeoIP_free() function

### DIFF
--- a/libGeoIP/GeoIP.c
+++ b/libGeoIP/GeoIP.c
@@ -2764,3 +2764,9 @@ int GeoIP_cleanup(void) {
 
     return result;
 }
+
+void GeoIP_free(void *ptr) {
+  if (ptr) {
+    free(ptr);
+  }
+}

--- a/libGeoIP/GeoIP.c
+++ b/libGeoIP/GeoIP.c
@@ -2765,6 +2765,6 @@ int GeoIP_cleanup(void) {
     return result;
 }
 
-void GeoIP_string_delete(void *ptr) {
+void GeoIP_string_delete(char *ptr) {
     free(ptr);
 }

--- a/libGeoIP/GeoIP.c
+++ b/libGeoIP/GeoIP.c
@@ -2765,8 +2765,6 @@ int GeoIP_cleanup(void) {
     return result;
 }
 
-void GeoIP_free(void *ptr) {
-  if (ptr) {
+void GeoIP_string_delete(void *ptr) {
     free(ptr);
-  }
 }

--- a/libGeoIP/GeoIP.h
+++ b/libGeoIP/GeoIP.h
@@ -301,7 +301,7 @@ GeoIP_name_by_name_v6_gl(GeoIP *gi, const char *name, GeoIPLookup *gl);
  * Windows where you may have different libraries linked with different
  * versions of the runtime (e.g. MT debug and MT release).
  */
-GEOIP_API void GeoIP_free(void *ptr);
+GEOIP_API void GeoIP_string_delete(void *ptr);
 
 /** return two letter country code */
 GEOIP_API const char *GeoIP_code_by_id(int id);

--- a/libGeoIP/GeoIP.h
+++ b/libGeoIP/GeoIP.h
@@ -301,7 +301,7 @@ GeoIP_name_by_name_v6_gl(GeoIP *gi, const char *name, GeoIPLookup *gl);
  * Windows where you may have different libraries linked with different
  * versions of the runtime (e.g. MT debug and MT release).
  */
-GEOIP_API void GeoIP_string_delete(void *ptr);
+GEOIP_API void GeoIP_string_delete(char *ptr);
 
 /** return two letter country code */
 GEOIP_API const char *GeoIP_code_by_id(int id);

--- a/libGeoIP/GeoIP.h
+++ b/libGeoIP/GeoIP.h
@@ -296,6 +296,13 @@ GeoIP_name_by_addr_v6_gl(GeoIP *gi, const char *addr, GeoIPLookup *gl);
 GEOIP_API char *
 GeoIP_name_by_name_v6_gl(GeoIP *gi, const char *name, GeoIPLookup *gl);
 
+/*
+ * Free a malloc()-ed string returned by other APIs. Handy to have on
+ * Windows where you may have different libraries linked with different
+ * versions of the runtime (e.g. MT debug and MT release).
+ */
+GEOIP_API void GeoIP_free(void *ptr);
+
 /** return two letter country code */
 GEOIP_API const char *GeoIP_code_by_id(int id);
 


### PR DESCRIPTION
Recently I spent some time on Windows trying to debug a crash occurring in `free()` caused by the fact that libgeoip was using the MT release C runtime, while my library was using the debug version of the same runtime.

While that should have been avoidable by making sure I was compiling with the correct runtime, I think it should also be nice to have an API that calls the `free()` matching the `malloc()` that has been used by GeoIP to allocate memory.

This way, one can just use `GeoIP_free()` to free memory that was allocated by GeoIP without wondering about the runtime that is used. A similar concept is `freeaddrinfo()` in libc.

Does this approach make sense?

P.S.  I know that I should migrate soon to `libmaxminddb` and I have that quite high in my TODO list but having this diff in libGeoIP will also probably be useful to me for a couple of months :).

Thanks!