### PR TITLE
remove build problems related to rpl_malloc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,8 +48,6 @@ AC_CHECK_FUNC(gethostbyname_r, [
 
 AC_CHECK_FUNCS([ memset memchr munmap strrchr socket strchr strdup strstr ])
 
-AC_FUNC_MALLOC
-AC_FUNC_REALLOC
 AC_FUNC_MMAP
 
 AC_ARG_ENABLE([data-files],


### PR DESCRIPTION
trying to cross compile with uclibc would raise rp_malloc undefined reference errors

see:
https://github.com/maxmind/libmaxminddb/pull/152
https://github.com/maxmind/libmaxminddb/issues/144